### PR TITLE
Add custom theme scaffold and hero section

### DIFF
--- a/custom-impulse-theme/README.md
+++ b/custom-impulse-theme/README.md
@@ -1,0 +1,17 @@
+# Custom Impulse Theme
+
+This folder contains a premium Shopify theme inspired by the `voorbeeldtemplate` structure.  It follows Online Store 2.0 conventions with modular sections and JSON templates.
+
+```
+custom-impulse-theme/
+├── assets/      # CSS, JS and media files
+├── blocks/      # Reusable content blocks
+├── config/      # Theme and settings schemas
+├── layout/      # Base layout files
+├── locales/     # Translation files
+├── sections/    # Liquid sections
+├── snippets/    # Small Liquid snippets
+└── templates/   # JSON templates combining sections
+```
+
+Currently the theme includes a flexible hero section with animation options.

--- a/custom-impulse-theme/assets/README.md
+++ b/custom-impulse-theme/assets/README.md
@@ -1,0 +1,1 @@
+Placeholder for assets

--- a/custom-impulse-theme/blocks/README.md
+++ b/custom-impulse-theme/blocks/README.md
@@ -1,0 +1,1 @@
+Placeholder for blocks

--- a/custom-impulse-theme/config/settings_schema.json
+++ b/custom-impulse-theme/config/settings_schema.json
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "theme_info",
+    "theme_name": "Custom Impulse",
+    "theme_version": "1.0.0",
+    "theme_author": "Codex",
+    "theme_documentation_url": "https://example.com/docs",
+    "theme_support_url": "https://example.com/support"
+  },
+  {
+    "name": "t:general.colors",
+    "settings": [
+      {
+        "type": "color",
+        "id": "background",
+        "label": "t:labels.background",
+        "default": "#FFFFFF"
+      },
+      {
+        "type": "color",
+        "id": "foreground",
+        "label": "t:labels.foreground",
+        "default": "#000000"
+      },
+      {
+        "type": "checkbox",
+        "id": "dark_mode",
+        "label": "t:labels.dark_mode",
+        "default": false
+      }
+    ]
+  }
+]

--- a/custom-impulse-theme/layout/README.md
+++ b/custom-impulse-theme/layout/README.md
@@ -1,0 +1,1 @@
+Placeholder for layout

--- a/custom-impulse-theme/locales/en.default.json
+++ b/custom-impulse-theme/locales/en.default.json
@@ -1,0 +1,41 @@
+{
+  "sections": {
+    "hero": {
+      "name": "Hero section",
+      "settings": {
+        "full_height": "Full height",
+        "autoplay": "Autoplay",
+        "autoplay_speed": "Autoplay speed",
+        "overlay_color": "Overlay color",
+        "overlay_opacity": "Overlay opacity",
+        "lazy_load": "Lazy load images"
+      },
+      "blocks": {
+        "slide": {
+          "name": "Slide",
+          "settings": {
+            "image": "Image",
+            "video": "Video URL",
+            "heading": "Heading",
+            "subheading": "Subheading",
+            "button_label": "Button label",
+            "button_link": "Button link",
+            "text_align": "Text align",
+            "text_color": "Text color",
+            "animation_style": "Animation style"
+          }
+        }
+      }
+    }
+  },
+  "labels": {
+    "background": "Background color",
+    "foreground": "Foreground color",
+    "dark_mode": "Enable dark mode"
+  },
+  "options": {
+    "left": "Left",
+    "center": "Center",
+    "right": "Right"
+  }
+}

--- a/custom-impulse-theme/locales/nl.default.json
+++ b/custom-impulse-theme/locales/nl.default.json
@@ -1,0 +1,41 @@
+{
+  "sections": {
+    "hero": {
+      "name": "Hero sectie",
+      "settings": {
+        "full_height": "Volledige hoogte",
+        "autoplay": "Automatisch afspelen",
+        "autoplay_speed": "Snelheid automatisch afspelen",
+        "overlay_color": "Overlay kleur",
+        "overlay_opacity": "Overlay dekking",
+        "lazy_load": "Afbeeldingen lazy load"
+      },
+      "blocks": {
+        "slide": {
+          "name": "Slide",
+          "settings": {
+            "image": "Afbeelding",
+            "video": "Video URL",
+            "heading": "Kop",
+            "subheading": "Subkop",
+            "button_label": "Knop label",
+            "button_link": "Knop link",
+            "text_align": "Tekst uitlijning",
+            "text_color": "Tekstkleur",
+            "animation_style": "Animatiestijl"
+          }
+        }
+      }
+    }
+  },
+  "labels": {
+    "background": "Achtergrondkleur",
+    "foreground": "Voorgrondkleur",
+    "dark_mode": "Dark mode inschakelen"
+  },
+  "options": {
+    "left": "Links",
+    "center": "Midden",
+    "right": "Rechts"
+  }
+}

--- a/custom-impulse-theme/sections/hero.liquid
+++ b/custom-impulse-theme/sections/hero.liquid
@@ -1,0 +1,96 @@
+{% comment %}
+  Flexible hero section with slideshow support and optional animations.
+  Each block acts as a slide with image/video, heading and call to action.
+  Animation styles use simple CSS transitions for performance.
+{% endcomment %}
+
+<section id="Hero-{{ section.id }}" class="hero-section {% if section.settings.full_height %}hero-section--full{% endif %}" style="--overlay-color: {{ section.settings.overlay_color }}; --overlay-opacity: {{ section.settings.overlay_opacity | divided_by: 100.0 }};">
+  <div class="hero-section__slides">
+    {% for block in section.blocks %}
+      <div class="hero-section__slide animate-{{ block.settings.animation_style }}" {{ block.shopify_attributes }}>
+        {% if block.settings.video != blank %}
+          <video class="hero-section__media" muted loop playsinline {% if section.settings.lazy_load %}loading="lazy"{% endif %}>
+            <source src="{{ block.settings.video }}" type="video/mp4">
+          </video>
+        {% elsif block.settings.image %}
+          {{ block.settings.image | image_url: width: 3000 | image_tag: class: 'hero-section__media', loading: section.settings.lazy_load ? 'lazy' : 'eager' }}
+        {% endif %}
+        <div class="hero-section__content text-{{ block.settings.text_align }}" style="--text-color: {{ block.settings.text_color }}">
+          {% if block.settings.heading != blank %}
+            <h2 class="hero-section__heading">{{ block.settings.heading }}</h2>
+          {% endif %}
+          {% if block.settings.subheading != blank %}
+            <p class="hero-section__subheading">{{ block.settings.subheading }}</p>
+          {% endif %}
+          {% if block.settings.button_label != blank %}
+            <a href="{{ block.settings.button_link }}" class="btn">{{ block.settings.button_label }}</a>
+          {% endif %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+
+{% stylesheet %}
+.hero-section { position: relative; overflow: hidden; }
+.hero-section--full { height: 100vh; }
+.hero-section__slides { display: grid; grid-template-areas: 'slide'; }
+.hero-section__slide { grid-area: slide; position: relative; opacity: 0; transition: opacity 0.8s ease; }
+.hero-section__slide.active { opacity: 1; }
+.hero-section__media { width: 100%; height: 100%; object-fit: cover; }
+.hero-section__content { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; flex-direction: column; text-align: inherit; color: var(--text-color, #fff); z-index: 2; padding: 1rem; }
+.hero-section__slide::after { content: ''; position: absolute; inset: 0; background: var(--overlay-color, #000); opacity: var(--overlay-opacity, 0.4); z-index: 1; }
+.animate-fade { animation: fadeIn 1s both; }
+.animate-slide { animation: slideIn 1s both; }
+@keyframes fadeIn { from { opacity:0; transform: translateY(20px); } to { opacity:1; transform:translateY(0);} }
+@keyframes slideIn { from { opacity:0; transform: translateX(30px); } to { opacity:1; transform:translateX(0);} }
+{% endstylesheet %}
+
+{% javascript %}
+(() => {
+  const root = document.getElementById('Hero-{{ section.id }}');
+  if (!root) return;
+  const slides = root.querySelectorAll('.hero-section__slide');
+  let index = 0;
+  const show = (i) => {
+    slides.forEach((s, idx) => s.classList.toggle('active', idx === i));
+  };
+  const next = () => { index = (index + 1) % slides.length; show(index); };
+  show(index);
+  {% if section.settings.autoplay %}
+    setInterval(next, {{ section.settings.autoplay_speed | times: 1000 }});
+  {% endif %}
+})();
+{% endjavascript %}
+
+{% schema %}
+{
+  "name": "t:sections.hero.name",
+  "settings": [
+    { "type": "checkbox", "id": "full_height", "label": "t:sections.hero.settings.full_height", "default": false },
+    { "type": "checkbox", "id": "autoplay", "label": "t:sections.hero.settings.autoplay", "default": false },
+    { "type": "range", "id": "autoplay_speed", "label": "t:sections.hero.settings.autoplay_speed", "min": 3, "max": 10, "step": 1, "unit": "s", "default": 5 },
+    { "type": "color", "id": "overlay_color", "label": "t:sections.hero.settings.overlay_color", "default": "#000000" },
+    { "type": "range", "id": "overlay_opacity", "label": "t:sections.hero.settings.overlay_opacity", "min": 0, "max": 100, "default": 40, "unit": "%" },
+    { "type": "checkbox", "id": "lazy_load", "label": "t:sections.hero.settings.lazy_load", "default": true }
+  ],
+  "blocks": [
+    {
+      "type": "slide",
+      "name": "t:sections.hero.blocks.slide.name",
+      "settings": [
+        { "type": "image_picker", "id": "image", "label": "t:sections.hero.blocks.slide.settings.image" },
+        { "type": "url", "id": "video", "label": "t:sections.hero.blocks.slide.settings.video", "info": "t:sections.hero.blocks.slide.settings.video_info" },
+        { "type": "text", "id": "heading", "label": "t:sections.hero.blocks.slide.settings.heading" },
+        { "type": "textarea", "id": "subheading", "label": "t:sections.hero.blocks.slide.settings.subheading" },
+        { "type": "text", "id": "button_label", "label": "t:sections.hero.blocks.slide.settings.button_label" },
+        { "type": "url", "id": "button_link", "label": "t:sections.hero.blocks.slide.settings.button_link" },
+        { "type": "select", "id": "text_align", "label": "t:sections.hero.blocks.slide.settings.text_align", "default": "center", "options": [ { "value": "left", "label": "t:options.left" }, { "value": "center", "label": "t:options.center" }, { "value": "right", "label": "t:options.right" } ] },
+        { "type": "color", "id": "text_color", "label": "t:sections.hero.blocks.slide.settings.text_color", "default": "#ffffff" },
+        { "type": "select", "id": "animation_style", "label": "t:sections.hero.blocks.slide.settings.animation_style", "default": "fade", "options": [ { "value": "fade", "label": "Fade" }, { "value": "slide", "label": "Slide" } ] }
+      ]
+    }
+  ],
+  "presets": [ { "name": "t:sections.hero.presets.name" } ]
+}
+{% endschema %}

--- a/custom-impulse-theme/snippets/README.md
+++ b/custom-impulse-theme/snippets/README.md
@@ -1,0 +1,1 @@
+Placeholder for snippets

--- a/custom-impulse-theme/templates/README.md
+++ b/custom-impulse-theme/templates/README.md
@@ -1,0 +1,1 @@
+Placeholder for templates


### PR DESCRIPTION
## Summary
- scaffold `custom-impulse-theme` folder structure
- add theme settings schema and locales
- implement flexible hero section with animation options

## Testing
- `theme-check custom-impulse-theme` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc5f170c4832d87dca7d89939aff5